### PR TITLE
Fix admin Solr load link

### DIFF
--- a/labs/backend/admin.py
+++ b/labs/backend/admin.py
@@ -21,6 +21,11 @@ class MyAdminSite(AdminSite):
                 self.admin_view(views.load_from_github),
                 name="load_from_github",
             ),
+            re_path(
+                r"^load_solr/$",
+                self.admin_view(views.load_solr),
+                name="load_solr",
+            ),
             re_path(r"^load_fuseki/$", self.admin_view(views.load_fuseki), name="load_fuseki"),
             re_path(
                 r"^backend/serverstatus/$",

--- a/labs/backend/templates/admin/data/dataset/change_list.html
+++ b/labs/backend/templates/admin/data/dataset/change_list.html
@@ -8,7 +8,7 @@
     </a>
   </li>
   <li>
-    <a href="{% url 'admin:solr' %}" class="">
+    <a href="{% url 'admin:load_solr' %}" class="">
      Load in solr
     </a>
   </li>


### PR DESCRIPTION
## Summary
- register a Solr loading view in admin
- point the Dataset admin page to the new view

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68405d31d0c88330a1f2545c840ecddf