### PR TITLE
Add admin panel for running management commands

### DIFF
--- a/labs/backend/admin.py
+++ b/labs/backend/admin.py
@@ -35,6 +35,11 @@ class MyAdminSite(AdminSite):
             re_path(
                 r"^backend/commands/$", self.admin_view(views.django_commands), name="commands"
             ),
+            re_path(
+                r"^backend/run_command/(?P<command>[^/]+)/$",
+                self.admin_view(views.run_django_command),
+                name="run_command",
+            ),
         ] + urls
         return urls
 

--- a/labs/backend/templates/admin/commands.html
+++ b/labs/backend/templates/admin/commands.html
@@ -23,6 +23,7 @@
         <tr>
           <th>{% trans 'Command' %}</th>
           <th>{% trans 'Description' %}</th>
+          <th>{% trans 'Run' %}</th>
         </tr>
       </thead>
       <tbody>
@@ -30,6 +31,30 @@
         <tr>
           <th scope="row">{{ cmd.name }}</th>
           <td>{{ cmd.help }}</td>
+          <td><a href="{% url 'admin:run_command' cmd.name %}">{% trans 'Run' %}</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="app-backend module">
+    <h2>{% trans 'Recent tasks' %}</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>{% trans 'Command' %}</th>
+          <th>{% trans 'Status' %}</th>
+          <th>{% trans 'Last log entry' %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for task in tasks %}
+        <tr>
+          <th scope="row">{{ task.name }}</th>
+          <td>
+            {% if task.is_done %}{% trans 'completed' %}{% else %}{% trans 'running' %}{% endif %}
+          </td>
+          <td>{{ task.last_log }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/labs/backend/views.py
+++ b/labs/backend/views.py
@@ -133,8 +133,17 @@ def django_commands(request):
             cmd_class = management.load_command_class("data", cmd)
             cmds.append({"name": cmd, "help": getattr(cmd_class, "help", "")})
 
+    tasks = models.ThreadTask.objects.all().order_by("-started")[:20]
+
     context = {
         "site_header": admin.admin_site.site_header,
         "cmds": cmds,
+        "tasks": tasks,
     }
     return render(request, "admin/commands.html", context)
+
+
+def run_django_command(request, command):
+    """Run a management command asynchronously and redirect back."""
+    tasks.call_command_as_task(command)
+    return redirect(reverse("admin:commands"))


### PR DESCRIPTION
## Summary
- enable running Django management commands from the admin panel
- show recent tasks and their statuses in commands admin page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684065bb7714833094e1a62faf580e08